### PR TITLE
Use merge for extending custom steps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,12 +2,16 @@
   "name": "cypress-scenario-runner",
   "version": "1.1.3",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "faker": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
       "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "node": ">=6.0"
   },
   "dependencies": {
-    "faker": "^4.1.0"
+    "faker": "^4.1.0",
+    "lodash.merge": "^4.6.1"
   },
   "peerDependencies": {
     "cypress": "^3.0.3",

--- a/src/init-steps.js
+++ b/src/init-steps.js
@@ -1,3 +1,4 @@
+const merge = require('lodash.merge');
 const defaultSteps = require('./steps');
 const defaultBehaviors = require('./behaviors');
 
@@ -5,7 +6,7 @@ const beforeFns = [];
 const afterFns = [];
 
 function initSteps({ given, when, then, customSteps, actions: customActions, assertions: customAssertions, preconditions: customPreconditions }) {
-	const steps = Object.assign({}, defaultSteps, customSteps);
+	const steps = merge({}, defaultSteps, customSteps);
 	const actions = Object.assign({}, defaultBehaviors.actions, customActions);
 	const assertions = Object.assign({}, defaultBehaviors.assertions, customAssertions);
 	const preconditions = Object.assign({}, defaultBehaviors.preconditions, customPreconditions);


### PR DESCRIPTION
```
const customSteps = {
	actions: {
		useShortLink: 'I use shortlink {element}',
	}
};

const defaultSteps = {
	actions: {
		logout: 'I log out',
                login: 'I log in as {user}',
		navigate: 'I navigate to {page}',
		...
	},
        ...
};

const steps = Object.assign({}, defaultSteps, customSteps);
// === {
	actions: {
		useShortLink: 'I use shortlink {element}',
	},
        ...
};
```

This would override the default custom steps; Object.assign is a shallow merge, and would override default actions.

Added merge, which is a deep extend.

