### PR TITLE
Ensure the page reloads if visiting the same page

### DIFF
--- a/src/behaviors.js
+++ b/src/behaviors.js
@@ -14,6 +14,9 @@ module.exports = {
 
 		navigate: function(page, table, { pages }) {
 			cy.visit(pages[page] || page);
+			// Sometimes visiting the same page causes the page to not load:
+			// https://github.com/cypress-io/cypress/issues/1311
+			cy.reload(true);
 		},
 
 		click: function(name) {


### PR DESCRIPTION
When using scenarios which load the same route over and over the page sometimes doesn't load:
https://github.com/cypress-io/cypress/issues/1311

Added a hard refresh to hopefully ensure the page loads on every page visit.